### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,48 +6,48 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-MCP342x		KEYWORD1
-Config		KEYWORD1
-Channel		KEYWORD1
-Mode		KEYWORD1
+MCP342x	KEYWORD1
+Config	KEYWORD1
+Channel	KEYWORD1
+Mode	KEYWORD1
 Resolution	KEYWORD1
-Gain		KEYWORD1
+Gain	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 generalCallReset	KEYWORD2
-generalCallLatch		KEYWORD2
-generalCallConversion		KEYWORD2
-normalise		KEYWORD2
+generalCallLatch	KEYWORD2
+generalCallConversion	KEYWORD2
+normalise	KEYWORD2
 autoprobe	KEYWORD2
 getAddress	KEYWORD2
 configure	KEYWORD2
-convert		KEYWORD2
-read		KEYWORD2
+convert	KEYWORD2
+read	KEYWORD2
 convertAndRead	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
-channel1		LITERAL1
-channel2		LITERAL1
-channel3		LITERAL1
-channel4		LITERAL1
-oneShot			LITERAL1
-continous		LITERAL1
-resolution12		LITERAL1
-resolution14		LITERAL1
-resolution16		LITERAL1
-resolution18		LITERAL1
-gain1			LITERAL1
-gain2			LITERAL1
-gain4			LITERAL1
-gain8			LITERAL1
-notReadyMask		LITERAL1
+channel1	LITERAL1
+channel2	LITERAL1
+channel3	LITERAL1
+channel4	LITERAL1
+oneShot	LITERAL1
+continous	LITERAL1
+resolution12	LITERAL1
+resolution14	LITERAL1
+resolution16	LITERAL1
+resolution18	LITERAL1
+gain1	LITERAL1
+gain2	LITERAL1
+gain4	LITERAL1
+gain8	LITERAL1
+notReadyMask	LITERAL1
 newConversionMask	LITERAL1
-numChannels		LITERAL1
-maxResolution		LITERAL1
-maxGain			LITERAL1
-writeTimeout_us		LITERAL1
+numChannels	LITERAL1
+maxResolution	LITERAL1
+maxGain	LITERAL1
+writeTimeout_us	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords